### PR TITLE
chore: replace console.log() with debug

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 const mysql = require('mysql');
 const path = require('path');
 const cp = require('child_process');
+const debug = require('debug')('node-mysql-import');
 
 module.exports = function(hostname, port, username, password, database, file ){
 
@@ -9,7 +10,7 @@ module.exports = function(hostname, port, username, password, database, file ){
     this.mysqlExecutable = null;
 
     this.init = function(){
-        console.log('initialize');
+        debug('initialize');
 
         return new Promise(function(resolve, reject){
 
@@ -25,7 +26,7 @@ module.exports = function(hostname, port, username, password, database, file ){
                 port: port,
                 user: username,
                 password: password,
-                multipleStatements: true 
+                multipleStatements: true
             });
 
             this.pool.getConnection((error, connection) => {
@@ -39,15 +40,15 @@ module.exports = function(hostname, port, username, password, database, file ){
             });
 
         });
-    }    
+    }
 
     this.dropDatabaseIfExists = function(){
-        console.log('drop database')
+        debug('drop database')
 
         return new Promise(function(resolve, reject){
             // WE USE DIRECT QUERY BECAUSE THE MYSQL MODULE DOES NOT PROPERLY HANDLE QUOTATION MARKS WITH THIS TYPE OF QUERY
             this.pool.query('DROP DATABASE IF EXISTS ' + database, function(error, result){
-                console.dir(result)
+                debug('result %j', result)
                 if(error)
                 {
                     reject(error);
@@ -62,7 +63,7 @@ module.exports = function(hostname, port, username, password, database, file ){
     }
 
     this.createDatabaseIfDoesNotExist = function(){
-        console.log('create database')
+        debug('create database')
         return new Promise(function (resolve, reject) {
             // WE USE DIRECT QUERY BECAUSE MYSQL MODULE DOES NOT PROPERLY HANDLE QUOTATION MARKS
             this.pool.query('CREATE DATABASE IF NOT EXISTS ' + database, function (error, result) {
@@ -74,7 +75,7 @@ module.exports = function(hostname, port, username, password, database, file ){
                     resolve(result);
                 }
             });
-        });        
+        });
     }
 
 
@@ -142,9 +143,9 @@ module.exports = function(hostname, port, username, password, database, file ){
                                 })
                             }
                         });
-                        
+
                     }
-                    
+
                 }
             });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,49 +1,62 @@
 {
-  "name": "mysql-import",
-  "version": "1.0.0",
+  "name": "node-mysql-import",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "bignumber.js": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
-      "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
     },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "mysql": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.16.0.tgz",
-      "integrity": "sha512-dPbN2LHonQp7D5ja5DJXNbCLe/HRdu+f3v61aguzNRQIrmZLOeRoymBYyeThrR6ug+FqzDL95Gc9maqZUJS+Gw==",
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.18.1.tgz",
+      "integrity": "sha512-Bca+gk2YWmqp2Uf6k5NFEurwY/0td0cpebAucFpY/3jhrwrVGuxU2uQFCHjU19SJfje0yQvi+rVWdq78hR5lig==",
       "requires": {
-        "bignumber.js": "4.1.0",
-        "readable-stream": "2.3.6",
+        "bignumber.js": "9.0.0",
+        "readable-stream": "2.3.7",
         "safe-buffer": "5.1.2",
         "sqlstring": "2.3.1"
       }
     },
     "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "Resul Polat",
   "license": "ISC",
   "dependencies": {
-    "mysql": "^2.16.0"
+    "debug": "^4.1.1",
+    "mysql": "^2.18.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,5 @@
 const MySQLImporter = require('../lib/index.js');
 
-
 // setup
 var test = new MySQLImporter('localhost', 3306, 'root', 'password', 'database', 'test.sql');
 


### PR DESCRIPTION
Adds in the debug module to remove `console.log()` calls when called from
other scripts.  To get logging information, you need to set the DEBUG
environment variable with the node-mysql-import name.

USAGE:
DEBUG="node-mysql-import" node index.js